### PR TITLE
Add retro browser edition of Technopoly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # technopoly
-a competitive tech business simulation game with ai competitors, advanced market engines, and customtkinkter gui
+
+a competitive tech business simulation game with ai competitors, advanced market engines, and customtkinter gui
 
 create a company and compete against ai competitors in different markets, create products, develop strategies, and outcompete the AIs
 win by having a monopoly (your company has >=70% of the market cap of the stock market) or you're the only company left (you acquired everyone else)
@@ -7,3 +8,23 @@ win by having a monopoly (your company has >=70% of the market cap of the stock 
 run main.py after installing requirements
 
 will make a better readme at some pt lol
+
+---
+
+## Retro Web Edition (local browser build)
+
+The repository now also ships with a retro-styled web version of Technopoly for quick local play.
+
+### How to launch
+
+1. Open the `web/` folder.
+2. Double click `index.html` (or serve the directory with any static web server).
+3. The simulation runs entirely in the browser—no additional dependencies or build steps required.
+
+### What’s inside
+
+- **Retro neon interface** with CRT overlays, scanlines, and a synthwave color palette.
+- **Quarterly management gameplay** that lets you launch products, run marketing pushes, take loans, and battle rival corporations.
+- **AI competitor feed** that narrates opposing moves alongside a live valuation telemetry chart.
+
+Feel free to tweak the HTML/CSS/JS in `web/` to customize the experience or plug it into a more robust frontend workflow.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Technopoly · Retro Web Edition</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="crt-overlay"></div>
+    <header class="header">
+      <div class="title">Technopoly</div>
+      <div class="subtitle">Retro Web Edition</div>
+      <div class="timeline" id="timeline">Year 1984 · Quarter 1</div>
+    </header>
+
+    <main class="dashboard">
+      <section class="panel status-panel">
+        <h2>Status Console</h2>
+        <div class="metrics-grid">
+          <div class="metric">
+            <span class="label">Cash</span>
+            <span class="value" id="cash">$0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Revenue (Qtr)</span>
+            <span class="value" id="revenue">$0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Expenses (Qtr)</span>
+            <span class="value" id="expenses">$0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Valuation</span>
+            <span class="value" id="valuation">$0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Morale</span>
+            <span class="value" id="morale">0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Innovation</span>
+            <span class="value" id="innovation">0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Reputation</span>
+            <span class="value" id="reputation">0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Debt</span>
+            <span class="value" id="debt">$0</span>
+          </div>
+          <div class="metric">
+            <span class="label">Actions Remaining</span>
+            <span class="value" id="actions-remaining">0</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel portfolio-panel">
+        <h2>Product Line</h2>
+        <div id="product-list" class="product-list empty">No products launched yet.</div>
+      </section>
+
+      <section class="panel markets-panel">
+        <h2>Market Scanner</h2>
+        <div class="markets-grid" id="markets"></div>
+      </section>
+
+      <section class="panel actions-panel">
+        <h2>Command Console</h2>
+        <div class="action-buttons">
+          <button data-action="launch">Launch Neon Product</button>
+          <button data-action="marketing">Run Marketing Blitz</button>
+          <button data-action="hire">Hire Elite Talent</button>
+          <button data-action="rnd">R&amp;D Hyper Sprint</button>
+          <button data-action="loan">Secure Retro Loan</button>
+          <button data-action="repay">Service Debt</button>
+          <button data-action="advance" class="advance">Advance Quarter</button>
+        </div>
+        <div class="action-description" id="action-description">
+          Choose an action to guide Technopoly through the neon-lit markets of the future.
+        </div>
+      </section>
+
+      <section class="panel log-panel">
+        <h2>Newswire Feed</h2>
+        <div class="log" id="log"></div>
+      </section>
+
+      <section class="panel ai-panel">
+        <h2>Rival Corporations</h2>
+        <div id="ai-companies" class="ai-list"></div>
+      </section>
+
+      <section class="panel chart-panel">
+        <h2>Valuation Telemetry</h2>
+        <canvas id="valuation-chart" width="520" height="220" aria-label="Valuation history chart"></canvas>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Built for local play. Pop open this page in your browser and keep Technopoly thriving in the retro silicon frontier.
+      </p>
+    </footer>
+
+    <div class="modal hidden" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <div class="modal-content">
+        <h3 id="modal-title"></h3>
+        <div id="modal-body"></div>
+        <div class="modal-actions">
+          <button id="modal-confirm" class="confirm">Confirm</button>
+          <button id="modal-cancel" class="cancel">Cancel</button>
+        </div>
+      </div>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,968 @@
+const timelineEl = document.getElementById('timeline');
+const cashEl = document.getElementById('cash');
+const revenueEl = document.getElementById('revenue');
+const expensesEl = document.getElementById('expenses');
+const valuationEl = document.getElementById('valuation');
+const moraleEl = document.getElementById('morale');
+const innovationEl = document.getElementById('innovation');
+const reputationEl = document.getElementById('reputation');
+const debtEl = document.getElementById('debt');
+const actionsRemainingEl = document.getElementById('actions-remaining');
+const marketsContainer = document.getElementById('markets');
+const logEl = document.getElementById('log');
+const aiContainer = document.getElementById('ai-companies');
+const productListEl = document.getElementById('product-list');
+const actionDescriptionEl = document.getElementById('action-description');
+const valuationCanvas = document.getElementById('valuation-chart');
+const valuationCtx = valuationCanvas.getContext('2d');
+
+const modalEl = document.getElementById('modal');
+const modalTitleEl = document.getElementById('modal-title');
+const modalBodyEl = document.getElementById('modal-body');
+const modalConfirmEl = document.getElementById('modal-confirm');
+const modalCancelEl = document.getElementById('modal-cancel');
+
+const actionDetails = {
+  launch: {
+    title: 'Launch Neon Product',
+    description:
+      'Invest capital to ship a synthwave-inspired product into a market of your choice. Boosts share, reputation, and future revenue.',
+  },
+  marketing: {
+    title: 'Run Marketing Blitz',
+    description:
+      'Flashy trade shows, vaporwave commercials, and magazine spreads energise the crowd. Raises reputation and morale while nudging market share.',
+  },
+  hire: {
+    title: 'Hire Elite Talent',
+    description:
+      'Recruit legendary engineers from the arcade halls. Improves innovation, morale, and product performance.',
+  },
+  rnd: {
+    title: 'R&D Hyper Sprint',
+    description:
+      'Focus the labs on radical experiments. Innovation skyrockets and markets get excited for the next big reveal.',
+  },
+  loan: {
+    title: 'Secure Retro Loan',
+    description:
+      'Accept funding from a neon-clad venture banker. Gain cash now with quarterly interest payments.',
+  },
+  repay: {
+    title: 'Service Debt',
+    description:
+      'Pay down principal to cut interest costs and keep creditors cool.',
+  },
+  advance: {
+    title: 'Advance Quarter',
+    description:
+      'Lock in this quarter’s outcomes, process events, and face rival moves. Refreshes available actions.',
+  },
+};
+
+const productNames = [
+  'Neon Nexus OS',
+  'HyperDrive Cloud',
+  'SynthWave Console',
+  'Circuit City CRM',
+  'LaserLink Modem',
+  'Chromatic AI Suite',
+  'Quantum Pulse Chipset',
+  'Midnight Matrix VR',
+  'PixelPay Network',
+  'RetroVision HUD',
+  'Arcade Analytics',
+  'Flux Capacitor Drive',
+  'VaporChat Social',
+  'TurboTape Backup',
+  'Celestial Compute Grid',
+  'IonBeam Robotics',
+  'ByteRider Drone',
+  'HoloSynth Entertainment',
+  'Lumen Ledger',
+  'Photon Courier Platform',
+];
+
+const marketsBlueprint = [
+  { name: 'Artificial Intelligence', baseValue: 8000000, hype: 0.95, volatility: 0.35 },
+  { name: 'Cloud Computing', baseValue: 6500000, hype: 0.82, volatility: 0.3 },
+  { name: 'Cybersecurity', baseValue: 5600000, hype: 0.74, volatility: 0.28 },
+  { name: 'Enterprise SaaS', baseValue: 5000000, hype: 0.68, volatility: 0.24 },
+  { name: 'E-Commerce', baseValue: 5400000, hype: 0.71, volatility: 0.22 },
+  { name: 'Consumer Hardware', baseValue: 4700000, hype: 0.62, volatility: 0.32 },
+  { name: 'FinTech', baseValue: 5900000, hype: 0.77, volatility: 0.27 },
+  { name: 'Social Media', baseValue: 5200000, hype: 0.7, volatility: 0.26 },
+];
+
+const aiDescriptors = [
+  { name: 'SynthDyne Systems', style: 'Cutthroat', color: '#ff5db1' },
+  { name: 'NovaGrid Labs', style: 'Visionary', color: '#00d7ff' },
+  { name: 'ByteForge Dynamics', style: 'Efficient', color: '#ffd166' },
+  { name: 'Omnitech Verse', style: 'Experimental', color: '#95ff8f' },
+  { name: 'Hyperion Signal', style: 'Aggressive', color: '#ff8b5f' },
+];
+
+const eventDeck = [
+  {
+    name: 'Dot Matrix Buzz',
+    description: 'RetroTech magazine features your founder on the cover.',
+    effect(state) {
+      state.reputation = clamp(state.reputation + 7, 0, 100);
+      state.morale = clamp(state.morale + 4, 0, 100);
+      addLog('RetroTech cover story boosts your brand aura.', 'positive');
+    },
+  },
+  {
+    name: 'Arcade Expo Triumph',
+    description: 'Your booth steals the spotlight with neon vapor trails.',
+    effect(state) {
+      state.markets.forEach((market) => {
+        market.playerShare = clamp(market.playerShare + 1.8 + Math.random() * 2, 0, 95);
+        market.aiShare = Math.max(0, 100 - market.playerShare);
+      });
+      state.revenue += 120000;
+      addLog('Arcade Expo crowds chant your name. Orders spike.', 'positive');
+    },
+  },
+  {
+    name: 'Hardware Shortage',
+    description: 'A supply chain hiccup limits chip availability.',
+    effect(state) {
+      if (state.products.length === 0) {
+        addLog('Hardware shortage looms, but you have no hardware products yet.', 'warning');
+        return;
+      }
+      const penalty = Math.round(90000 + Math.random() * 60000);
+      state.expenses += penalty;
+      state.cash -= penalty;
+      state.innovation = clamp(state.innovation - 4, 0, 120);
+      addLog('Component shortage hikes costs and slows R&D.', 'negative');
+    },
+  },
+  {
+    name: 'Talent Exodus',
+    description: 'Rival recruiters stalk your break room.',
+    effect(state) {
+      state.morale = clamp(state.morale - 6, 0, 100);
+      state.reputation = clamp(state.reputation - 3, 0, 100);
+      addLog('A rival poaches a beloved engineer. Team morale dips.', 'negative');
+    },
+  },
+  {
+    name: 'Collector Craze',
+    description: 'Collectors bid on your limited edition hardware.',
+    effect(state) {
+      const bonus = Math.round(100000 + Math.random() * 90000);
+      state.cash += bonus;
+      state.revenue += Math.round(bonus * 0.4);
+      addLog('Collectors flock to your neon hardware. Cash surges.', 'positive');
+    },
+  },
+  {
+    name: 'Retro Regulations',
+    description: 'New compliance paperwork bogs everyone down.',
+    effect(state) {
+      const drag = Math.round(60000 + Math.random() * 40000);
+      state.expenses += drag;
+      state.cash -= drag;
+      addLog('Regulators demand extra filings. Expenses climb.', 'warning');
+    },
+  },
+  {
+    name: 'Arc Reactor Breakthrough',
+    description: 'Your labs pioneer a dazzling power efficiency trick.',
+    effect(state) {
+      state.innovation = clamp(state.innovation + 9, 0, 130);
+      state.revenue += 90000;
+      addLog('Breakthrough tech electrifies investors.', 'positive');
+    },
+  },
+];
+
+function createInitialState() {
+  const markets = marketsBlueprint.map((market) => {
+    const playerShare = randomRange(3, 9);
+    return {
+      ...market,
+      playerShare,
+      aiShare: Math.max(0, 100 - playerShare),
+      previousShare: playerShare,
+      lastDelta: 0,
+      narrative: 'Awaiting disruption...',
+      previousHype: market.hype,
+    };
+  });
+
+  return {
+    year: 1984,
+    quarter: 1,
+    cash: 750000,
+    revenue: 0,
+    expenses: 0,
+    valuation: 2500000,
+    morale: 68,
+    innovation: 55,
+    reputation: 48,
+    debt: 0,
+    actionsRemaining: 2,
+    products: [],
+    loans: [],
+    markets,
+    aiCompanies: generateAiCompanies(),
+    availableProductNames: [...productNames],
+    history: [2500000],
+    turn: 0,
+    gameOver: false,
+    lastDebtService: 0,
+  };
+}
+
+function generateAiCompanies() {
+  return aiDescriptors.map((descriptor, index) => ({
+    ...descriptor,
+    valuation: Math.round(3500000 + index * 950000 + Math.random() * 500000),
+    reputation: 55 + Math.random() * 20,
+    morale: 60 + Math.random() * 20,
+    narrative: 'Scheming in the neon shadows...'
+  }));
+}
+
+let gameState = createInitialState();
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function randomRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function formatMoney(value) {
+  const sign = value < 0 ? '-' : '';
+  const absValue = Math.abs(Math.round(value));
+  return `${sign}$${absValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+}
+
+function describeHype(hype) {
+  if (hype >= 1.05) return 'Explosive';
+  if (hype >= 0.85) return 'High';
+  if (hype >= 0.6) return 'Steady';
+  return 'Cooling';
+}
+
+function describeVolatility(volatility) {
+  if (volatility >= 0.35) return 'Wild';
+  if (volatility >= 0.28) return 'Active';
+  if (volatility >= 0.22) return 'Calm';
+  return 'Stable';
+}
+
+function drawProductName() {
+  if (gameState.availableProductNames.length === 0) {
+    return `Technopoly MK-${Math.floor(Math.random() * 90 + 10)}`;
+  }
+  const index = Math.floor(Math.random() * gameState.availableProductNames.length);
+  const [name] = gameState.availableProductNames.splice(index, 1);
+  return name;
+}
+
+function hasActionsAvailable() {
+  if (gameState.gameOver) {
+    addLog('Simulation concluded. Restart to continue.', 'warning');
+    return false;
+  }
+  if (gameState.actionsRemaining <= 0) {
+    addLog('No command cycles remain this quarter. Advance the clock.', 'warning');
+    return false;
+  }
+  return true;
+}
+
+function spendAction() {
+  gameState.actionsRemaining = Math.max(0, gameState.actionsRemaining - 1);
+  if (gameState.actionsRemaining === 0) {
+    addLog('Command console cooling down. Advance the quarter to refresh actions.', 'system');
+  }
+  renderStatus();
+}
+
+function spendCash(amount) {
+  gameState.cash -= amount;
+}
+
+function creditCash(amount) {
+  gameState.cash += amount;
+}
+
+function openModal({ title, body, confirmText = 'Confirm', cancelText = 'Cancel', onConfirm, onCancel, hideCancel = false }) {
+  modalTitleEl.textContent = title;
+  modalBodyEl.innerHTML = '';
+  if (typeof body === 'string') {
+    modalBodyEl.innerHTML = `<p>${body}</p>`;
+  } else {
+    modalBodyEl.appendChild(body);
+  }
+  modalConfirmEl.textContent = confirmText;
+  modalCancelEl.textContent = cancelText;
+  modalCancelEl.classList.toggle('is-hidden', hideCancel);
+  modalConfirmEl.classList.toggle('is-hidden', !onConfirm);
+
+  modalConfirmEl.onclick = () => {
+    if (!onConfirm) {
+      closeModal();
+      return;
+    }
+    const result = onConfirm();
+    if (result !== false) {
+      closeModal();
+    }
+  };
+
+  modalCancelEl.onclick = () => {
+    if (onCancel) {
+      onCancel();
+    }
+    closeModal();
+  };
+
+  modalEl.classList.remove('hidden');
+}
+
+function closeModal() {
+  modalEl.classList.add('hidden');
+}
+
+modalEl.addEventListener('click', (event) => {
+  if (event.target === modalEl) {
+    closeModal();
+  }
+});
+
+function render() {
+  renderStatus();
+  updateTimeline();
+  renderProducts();
+  renderMarkets();
+  renderAiCompanies();
+  drawValuationChart();
+}
+
+function renderStatus() {
+  cashEl.textContent = formatMoney(gameState.cash);
+  revenueEl.textContent = formatMoney(gameState.revenue);
+  expensesEl.textContent = formatMoney(gameState.expenses);
+  valuationEl.textContent = formatMoney(gameState.valuation);
+  moraleEl.textContent = `${Math.round(gameState.morale)}`;
+  innovationEl.textContent = `${Math.round(gameState.innovation)}`;
+  reputationEl.textContent = `${Math.round(gameState.reputation)}`;
+  debtEl.textContent = formatMoney(gameState.debt);
+  actionsRemainingEl.textContent = `${gameState.actionsRemaining}`;
+}
+
+function updateTimeline() {
+  timelineEl.textContent = `Year ${gameState.year} · Quarter ${gameState.quarter}`;
+}
+
+function renderProducts() {
+  productListEl.innerHTML = '';
+  if (gameState.products.length === 0) {
+    productListEl.classList.add('empty');
+    productListEl.textContent = 'No products launched yet.';
+    return;
+  }
+  productListEl.classList.remove('empty');
+  gameState.products.forEach((product) => {
+    const card = document.createElement('div');
+    card.className = 'product-card';
+
+    const name = document.createElement('div');
+    name.className = 'name';
+    name.textContent = product.name;
+
+    const market = document.createElement('div');
+    market.className = 'market';
+    market.textContent = product.market;
+
+    const quality = document.createElement('div');
+    quality.className = 'stat';
+    quality.innerHTML = `<span>Quality</span><span>${product.quality}</span>`;
+
+    const revenue = document.createElement('div');
+    revenue.className = 'stat';
+    revenue.innerHTML = `<span>Base Rev.</span><span>${formatMoney(product.baseRevenue)}</span>`;
+
+    card.append(name, market, quality, revenue);
+    productListEl.appendChild(card);
+  });
+}
+
+function renderMarkets() {
+  marketsContainer.innerHTML = '';
+  gameState.markets.forEach((market) => {
+    const card = document.createElement('div');
+    card.className = 'market-card';
+
+    const title = document.createElement('div');
+    title.className = 'market-title';
+    title.textContent = market.name;
+
+    const meta = document.createElement('div');
+    meta.className = 'market-meta';
+    meta.innerHTML = `<span>Hype: ${describeHype(market.hype)}</span><span>Volatility: ${describeVolatility(market.volatility)}</span>`;
+
+    const shareBar = document.createElement('div');
+    shareBar.className = 'share-bar';
+    const playerBar = document.createElement('div');
+    playerBar.className = 'player';
+    playerBar.style.width = `${clamp(market.playerShare, 0, 100).toFixed(1)}%`;
+    const aiBar = document.createElement('div');
+    aiBar.className = 'ai';
+    aiBar.style.width = `${clamp(market.aiShare, 0, 100).toFixed(1)}%`;
+    shareBar.append(playerBar, aiBar);
+
+    const trend = document.createElement('div');
+    trend.className = 'trend';
+    const arrow = market.lastDelta > 0.3 ? '▲' : market.lastDelta < -0.3 ? '▼' : '◆';
+    trend.textContent = `Player share: ${market.playerShare.toFixed(1)}% ${arrow}`;
+
+    const narrative = document.createElement('div');
+    narrative.className = 'trend';
+    narrative.textContent = market.narrative;
+
+    card.append(title, meta, shareBar, trend, narrative);
+    marketsContainer.appendChild(card);
+  });
+}
+
+function renderAiCompanies() {
+  aiContainer.innerHTML = '';
+  gameState.aiCompanies.forEach((ai) => {
+    const card = document.createElement('div');
+    card.className = 'ai-card';
+
+    const name = document.createElement('div');
+    name.className = 'name';
+    name.style.color = ai.color;
+    name.textContent = ai.name;
+
+    const style = document.createElement('div');
+    style.className = 'stat';
+    style.innerHTML = `<span>Persona</span><span>${ai.style}</span>`;
+
+    const valuation = document.createElement('div');
+    valuation.className = 'stat';
+    valuation.innerHTML = `<span>Valuation</span><span>${formatMoney(ai.valuation)}</span>`;
+
+    const reputation = document.createElement('div');
+    reputation.className = 'stat';
+    reputation.innerHTML = `<span>Reputation</span><span>${Math.round(ai.reputation)}</span>`;
+
+    const morale = document.createElement('div');
+    morale.className = 'stat';
+    morale.innerHTML = `<span>Morale</span><span>${Math.round(ai.morale)}</span>`;
+
+    const narrative = document.createElement('div');
+    narrative.className = 'stat';
+    narrative.style.justifyContent = 'flex-start';
+    narrative.style.color = 'rgba(255, 255, 255, 0.7)';
+    narrative.textContent = ai.narrative;
+
+    card.append(name, style, valuation, reputation, morale, narrative);
+    aiContainer.appendChild(card);
+  });
+}
+
+function drawValuationChart() {
+  const { width, height } = valuationCanvas;
+  valuationCtx.clearRect(0, 0, width, height);
+
+  valuationCtx.fillStyle = 'rgba(4, 8, 24, 0.9)';
+  valuationCtx.fillRect(0, 0, width, height);
+
+  const data = gameState.history.slice(-24);
+  if (data.length < 2) {
+    return;
+  }
+
+  const maxVal = Math.max(...data);
+  const minVal = Math.min(...data);
+  const range = maxVal - minVal || 1;
+
+  valuationCtx.strokeStyle = '#00ffd0';
+  valuationCtx.lineWidth = 2;
+  valuationCtx.beginPath();
+  data.forEach((val, index) => {
+    const x = (index / (data.length - 1)) * (width - 30) + 15;
+    const y = height - ((val - minVal) / range) * (height - 30) - 15;
+    if (index === 0) {
+      valuationCtx.moveTo(x, y);
+    } else {
+      valuationCtx.lineTo(x, y);
+    }
+  });
+  valuationCtx.stroke();
+
+  valuationCtx.fillStyle = 'rgba(0, 255, 208, 0.12)';
+  valuationCtx.lineTo(width - 15, height - 15);
+  valuationCtx.lineTo(15, height - 15);
+  valuationCtx.closePath();
+  valuationCtx.fill();
+}
+
+function addLog(message, tone = 'system') {
+  const entry = document.createElement('div');
+  entry.className = `log-entry ${tone}`;
+  entry.textContent = message;
+  logEl.appendChild(entry);
+  while (logEl.children.length > 80) {
+    logEl.removeChild(logEl.firstChild);
+  }
+}
+
+function updateValuation() {
+  const productValue = gameState.products.reduce((total, product) => total + product.baseRevenue * 6, 0);
+  const intangible = (gameState.reputation + gameState.innovation) * 9500;
+  const baseline = gameState.cash * 1.1 + gameState.revenue * 4;
+  const marketBonus = gameState.markets.reduce((total, market) => total + market.playerShare * (market.baseValue / 16), 0);
+  gameState.valuation = Math.max(1000000, Math.round(baseline + productValue + intangible + marketBonus));
+}
+
+function updateMarketNarratives() {
+  gameState.markets.forEach((market) => {
+    const hypeDescriptor = describeHype(market.hype);
+    let shareDescriptor = 'Presence minimal.';
+    if (market.playerShare > 35) {
+      shareDescriptor = 'Your neon signage dominates expo floors.';
+    } else if (market.playerShare > 20) {
+      shareDescriptor = 'Growing cult following among enthusiasts.';
+    } else if (market.playerShare > 8) {
+      shareDescriptor = 'Rumblings of interest echo through forums.';
+    }
+    const movement = market.lastDelta > 0.3 ? 'Momentum rising.' : market.lastDelta < -0.3 ? 'Competitors press harder.' : 'Holding the line.';
+    market.narrative = `${hypeDescriptor} hype. ${movement} ${shareDescriptor}`;
+  });
+}
+
+function advanceQuarter() {
+  if (gameState.gameOver) {
+    addLog('Simulation concluded. Restart to play again.', 'warning');
+    return;
+  }
+
+  const unusedActions = gameState.actionsRemaining;
+  if (unusedActions > 0) {
+    addLog(`Advancing with ${unusedActions} unused action(s).`, 'system');
+  }
+
+  gameState.actionsRemaining = 2;
+  gameState.quarter += 1;
+  if (gameState.quarter > 4) {
+    gameState.quarter = 1;
+    gameState.year += 1;
+  }
+  gameState.turn += 1;
+
+  let totalRevenue = 0;
+  let totalExpenses = 0;
+
+  gameState.markets.forEach((market) => {
+    const previousShare = market.playerShare;
+    const activeProducts = gameState.products.filter((product) => product.market === market.name);
+    if (activeProducts.length > 0) {
+      const hypeMultiplier = 0.8 + market.hype * 0.6;
+      const innovationBonus = 0.6 + gameState.innovation / 160;
+      const randomness = 0.82 + Math.random() * 0.32;
+      const shareFactor = market.playerShare / 100;
+      const marketRevenue = (market.baseValue / 4) * shareFactor * hypeMultiplier * innovationBonus * randomness;
+      totalRevenue += marketRevenue;
+      const upkeep = activeProducts.length * 52000 + shareFactor * 38000;
+      totalExpenses += upkeep;
+    }
+
+    const erosionBase = randomRange(0.6, 2.4) * market.volatility * 2.6;
+    const reputationShield = gameState.reputation / 70;
+    const erosion = Math.max(0, erosionBase - reputationShield);
+    market.playerShare = clamp(market.playerShare - erosion + gameState.innovation / 240, 0, 96);
+    market.aiShare = Math.max(0, 100 - market.playerShare);
+    market.lastDelta = market.playerShare - previousShare;
+
+    const hypeDrift = (Math.random() - 0.45) * market.volatility * 0.22;
+    market.previousHype = market.hype;
+    market.hype = clamp(market.hype + hypeDrift, 0.35, 1.35);
+  });
+
+  gameState.products.forEach((product) => {
+    const maturityBonus = 1 + Math.min(gameState.turn - product.launchedTurn, 6) * 0.03;
+    product.baseRevenue = Math.round(product.baseRevenue * (0.98 + Math.random() * 0.08) * maturityBonus);
+  });
+
+  const payroll = 140000 + gameState.products.length * 22000 + gameState.morale * 600;
+  const research = Math.max(0, (gameState.innovation - 40) * 2600);
+  totalExpenses += payroll + research;
+
+  let debtService = 0;
+  gameState.loans.forEach((loan) => {
+    const interestPayment = Math.round((loan.amount * loan.rate) / 4);
+    debtService += interestPayment;
+  });
+  totalExpenses += debtService;
+  gameState.lastDebtService = debtService;
+
+  gameState.revenue = Math.round(totalRevenue);
+  gameState.expenses = Math.round(totalExpenses);
+  gameState.cash += Math.round(totalRevenue - totalExpenses);
+
+  if (gameState.debt > 0) {
+    gameState.debt = Math.round(gameState.loans.reduce((sum, loan) => sum + loan.amount, 0));
+  }
+
+  gameState.morale = clamp(gameState.morale + randomRange(-4, 3) + gameState.revenue / 600000 - debtService / 90000, 0, 100);
+  gameState.innovation = clamp(gameState.innovation + randomRange(-2, 3) + gameState.products.length * 0.3, 0, 130);
+  gameState.reputation = clamp(gameState.reputation + randomRange(-1, 2), 0, 100);
+
+  processRandomEvent();
+  rivalTurns();
+  updateValuation();
+  updateMarketNarratives();
+
+  gameState.debt = Math.round(gameState.loans.reduce((sum, loan) => sum + loan.amount, 0));
+
+  gameState.history.push(gameState.valuation);
+  if (gameState.history.length > 96) {
+    gameState.history.shift();
+  }
+
+  addLog(`Quarter ${gameState.quarter} of ${gameState.year} processed. Revenue ${formatMoney(gameState.revenue)} · Expenses ${formatMoney(gameState.expenses)}.`, 'system');
+
+  render();
+  evaluateEndConditions();
+}
+
+function processRandomEvent() {
+  if (Math.random() < 0.6) {
+    const event = eventDeck[Math.floor(Math.random() * eventDeck.length)];
+    addLog(`[Event] ${event.name}: ${event.description}`, 'system');
+    event.effect(gameState);
+  }
+}
+
+function rivalTurns() {
+  gameState.aiCompanies.forEach((ai) => {
+    const roll = Math.random();
+    const targetMarket = gameState.markets[Math.floor(Math.random() * gameState.markets.length)];
+    if (roll < 0.33) {
+      const squeeze = randomRange(1.5, 3.8);
+      targetMarket.playerShare = clamp(targetMarket.playerShare - squeeze, 0, 95);
+      targetMarket.aiShare = Math.max(0, 100 - targetMarket.playerShare);
+      ai.valuation = Math.round(ai.valuation * (1.02 + Math.random() * 0.03));
+      ai.narrative = `Flooded ${targetMarket.name} with promos.`;
+      addLog(`${ai.name} floods ${targetMarket.name} with promotions.`, 'negative');
+    } else if (roll < 0.66) {
+      const steal = randomRange(1.2, 2.4);
+      gameState.reputation = clamp(gameState.reputation - 2, 0, 100);
+      targetMarket.playerShare = clamp(targetMarket.playerShare - steal, 0, 95);
+      targetMarket.aiShare = Math.max(0, 100 - targetMarket.playerShare);
+      ai.reputation = clamp(ai.reputation + 3, 0, 100);
+      ai.narrative = 'Captured headlines with a flashy reveal.';
+      addLog(`${ai.name} steals your spotlight with a retro-futuristic reveal.`, 'warning');
+    } else {
+      const moraleHit = randomRange(3, 6);
+      gameState.morale = clamp(gameState.morale - moraleHit, 0, 100);
+      ai.morale = clamp(ai.morale + 2, 0, 100);
+      ai.narrative = 'Poached a key technomancer from your labs.';
+      addLog(`${ai.name} poaches a key technomancer. Morale suffers.`, 'negative');
+    }
+
+    const drift = 1 + (Math.random() - 0.45) * 0.08;
+    ai.valuation = Math.max(1500000, Math.round(ai.valuation * drift));
+  });
+}
+
+function evaluateEndConditions() {
+  if (gameState.gameOver) {
+    return;
+  }
+  if (gameState.cash <= -350000 || gameState.morale <= 5 || gameState.debt >= 1500000) {
+    triggerGameOver(
+      'loss',
+      'Cash reserves depleted and morale collapsed. The neon lights flicker out at Technopoly HQ.'
+    );
+    return;
+  }
+  if (gameState.valuation >= 75000000 || gameState.reputation >= 92) {
+    triggerGameOver(
+      'win',
+      'Your retro-futuristic empire now dominates the silicon skyline. Investors chant your name.'
+    );
+  }
+}
+
+function triggerGameOver(type, message) {
+  gameState.gameOver = true;
+  addLog(message, type === 'win' ? 'positive' : 'negative');
+  openModal({
+    title: type === 'win' ? 'Victory Protocol' : 'Shutdown Warning',
+    body: message,
+    confirmText: 'Restart Simulation',
+    cancelText: 'Close',
+    onConfirm: () => {
+      restartGame();
+      return true;
+    },
+    onCancel: null,
+    hideCancel: true,
+  });
+}
+
+function restartGame() {
+  gameState = createInitialState();
+  logEl.innerHTML = '';
+  addLog('Simulation rebooted. Technopoly returns to the neon frontier.', 'system');
+  render();
+}
+
+function handleLaunchProduct() {
+  if (!hasActionsAvailable()) {
+    return;
+  }
+
+  const container = document.createElement('div');
+  container.innerHTML = '<p>Select a market to deploy your latest neon invention.</p>';
+
+  const select = document.createElement('select');
+  gameState.markets.forEach((market) => {
+    const option = document.createElement('option');
+    option.value = market.name;
+    option.textContent = `${market.name} · Hype ${describeHype(market.hype)}`;
+    select.appendChild(option);
+  });
+  container.appendChild(select);
+
+  openModal({
+    title: 'Launch Neon Product',
+    body: container,
+    confirmText: 'Deploy',
+    onConfirm: () => {
+      const marketName = select.value;
+      const market = gameState.markets.find((m) => m.name === marketName);
+      const launchCost = 200000;
+      if (gameState.cash < launchCost) {
+        addLog(`Need ${formatMoney(launchCost)} to launch.`, 'warning');
+        return false;
+      }
+      spendCash(launchCost);
+      const quality = Math.round(60 + Math.random() * 30 + gameState.innovation * 0.25);
+      const baseRevenue = Math.round(market.baseValue * randomRange(0.05, 0.11));
+      const product = {
+        id: `${Date.now()}-${Math.floor(Math.random() * 999)}`,
+        name: drawProductName(),
+        market: market.name,
+        quality,
+        baseRevenue,
+        launchedTurn: gameState.turn,
+      };
+      gameState.products.push(product);
+      market.playerShare = clamp(market.playerShare + 6 + quality / 18 + gameState.reputation / 25, 0, 96);
+      market.aiShare = Math.max(0, 100 - market.playerShare);
+      gameState.innovation = clamp(gameState.innovation + 5 + Math.random() * 3, 0, 130);
+      gameState.reputation = clamp(gameState.reputation + 4 + Math.random() * 2, 0, 100);
+      addLog(`Product launch success! ${product.name} hits ${market.name}.`, 'positive');
+      spendAction();
+      render();
+      return true;
+    },
+  });
+}
+
+function runMarketingBlitz() {
+  const cost = 100000;
+  if (!hasActionsAvailable() || gameState.cash < cost) {
+    if (gameState.cash < cost) {
+      addLog(`Marketing blitz requires ${formatMoney(cost)}.`, 'warning');
+    }
+    return;
+  }
+  spendCash(cost);
+  const repGain = Math.round(randomRange(6, 11));
+  const moraleGain = Math.round(randomRange(3, 6));
+  gameState.reputation = clamp(gameState.reputation + repGain, 0, 100);
+  gameState.morale = clamp(gameState.morale + moraleGain, 0, 100);
+  gameState.markets.forEach((market) => {
+    const boost = randomRange(0.6, 1.6);
+    market.playerShare = clamp(market.playerShare + boost, 0, 95);
+    market.aiShare = Math.max(0, 100 - market.playerShare);
+  });
+  addLog(`Marketing blitz dazzles the airwaves. Reputation +${repGain}, morale +${moraleGain}.`, 'positive');
+  spendAction();
+  render();
+}
+
+function hireTalent() {
+  const cost = 75000;
+  if (!hasActionsAvailable() || gameState.cash < cost) {
+    if (gameState.cash < cost) {
+      addLog(`Elite talent demands ${formatMoney(cost)} signing bonuses.`, 'warning');
+    }
+    return;
+  }
+  spendCash(cost);
+  const innovationBoost = randomRange(5, 9);
+  const moraleBoost = randomRange(5, 8);
+  gameState.innovation = clamp(gameState.innovation + innovationBoost, 0, 130);
+  gameState.morale = clamp(gameState.morale + moraleBoost, 0, 100);
+  gameState.products.forEach((product) => {
+    product.baseRevenue = Math.round(product.baseRevenue * (1 + innovationBoost / 140));
+  });
+  addLog('Legendary engineers join Technopoly. Innovation soars.', 'positive');
+  spendAction();
+  render();
+}
+
+function researchSprint() {
+  const cost = 60000;
+  if (!hasActionsAvailable() || gameState.cash < cost) {
+    if (gameState.cash < cost) {
+      addLog(`R&D sprint needs ${formatMoney(cost)} in lab equipment.`, 'warning');
+    }
+    return;
+  }
+  spendCash(cost);
+  const innovationGain = randomRange(7, 12);
+  const hypeBoost = randomRange(0.03, 0.08);
+  gameState.innovation = clamp(gameState.innovation + innovationGain, 0, 135);
+  gameState.markets.forEach((market) => {
+    market.hype = clamp(market.hype + hypeBoost - market.volatility * 0.02, 0.35, 1.4);
+  });
+  addLog('R&D labs glow electric blue. Innovation leaps forward.', 'positive');
+  spendAction();
+  render();
+}
+
+function secureLoan() {
+  if (!hasActionsAvailable()) {
+    return;
+  }
+  const container = document.createElement('div');
+  container.innerHTML = '<p>Select funding to wire from the retro bank (50k - 500k).</p>';
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '50000';
+  input.max = '500000';
+  input.step = '5000';
+  input.value = '150000';
+  container.appendChild(input);
+
+  openModal({
+    title: 'Secure Retro Loan',
+    body: container,
+    confirmText: 'Accept Funds',
+    onConfirm: () => {
+      const amount = Number(input.value);
+      if (Number.isNaN(amount) || amount < 50000) {
+        addLog('Minimum loan is $50,000.', 'warning');
+        return false;
+      }
+      if (amount > 500000) {
+        addLog('Retro banker declines anything above $500,000.', 'warning');
+        return false;
+      }
+      creditCash(amount);
+      gameState.loans.push({ amount, rate: 0.08 });
+      gameState.debt = Math.round(gameState.loans.reduce((sum, loan) => sum + loan.amount, 0));
+      addLog(`Loan secured for ${formatMoney(amount)} at 8% APR.`, 'system');
+      spendAction();
+      render();
+      return true;
+    },
+  });
+}
+
+function serviceDebt() {
+  if (gameState.debt <= 0) {
+    addLog('No outstanding debt to service.', 'system');
+    return;
+  }
+  if (!hasActionsAvailable()) {
+    return;
+  }
+  const container = document.createElement('div');
+  container.innerHTML = `<p>Outstanding debt: ${formatMoney(gameState.debt)}. Enter payment amount.</p>`;
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '25000';
+  input.step = '5000';
+  input.value = '50000';
+  container.appendChild(input);
+
+  openModal({
+    title: 'Service Debt',
+    body: container,
+    confirmText: 'Submit Payment',
+    onConfirm: () => {
+      let amount = Number(input.value);
+      if (Number.isNaN(amount) || amount <= 0) {
+        addLog('Enter a valid payment amount.', 'warning');
+        return false;
+      }
+      amount = Math.min(amount, gameState.debt);
+      if (gameState.cash < amount) {
+        addLog('Not enough cash to cover that payment.', 'warning');
+        return false;
+      }
+      spendCash(amount);
+      let remaining = amount;
+      for (const loan of gameState.loans) {
+        if (remaining <= 0) break;
+        const pay = Math.min(loan.amount, remaining);
+        loan.amount -= pay;
+        remaining -= pay;
+      }
+      gameState.loans = gameState.loans.filter((loan) => loan.amount > 0);
+      gameState.debt = Math.round(gameState.loans.reduce((sum, loan) => sum + loan.amount, 0));
+      addLog(`Paid ${formatMoney(amount)} toward outstanding loans.`, 'positive');
+      spendAction();
+      render();
+      return true;
+    },
+  });
+}
+
+const actions = {
+  launch: handleLaunchProduct,
+  marketing: runMarketingBlitz,
+  hire: hireTalent,
+  rnd: researchSprint,
+  loan: secureLoan,
+  repay: serviceDebt,
+  advance: advanceQuarter,
+};
+
+document.querySelectorAll('[data-action]').forEach((button) => {
+  const action = button.dataset.action;
+  button.addEventListener('click', () => {
+    const handler = actions[action];
+    if (handler) {
+      handler();
+    }
+  });
+  button.addEventListener('mouseenter', () => {
+    const info = actionDetails[action];
+    if (info) {
+      actionDescriptionEl.textContent = info.description;
+    }
+  });
+  button.addEventListener('focus', () => {
+    const info = actionDetails[action];
+    if (info) {
+      actionDescriptionEl.textContent = info.description;
+    }
+  });
+});
+
+document.querySelector('.actions-panel').addEventListener('mouseleave', () => {
+  actionDescriptionEl.textContent =
+    'Choose an action to guide Technopoly through the neon-lit markets of the future.';
+});
+
+addLog('Welcome to Technopoly: Retro Web Edition. Keep the neon lights glowing and outmaneuver rivals.', 'system');
+render();

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,519 @@
+:root {
+  --bg-top: #04060f;
+  --bg-bottom: #080d24;
+  --panel-bg: rgba(12, 18, 48, 0.85);
+  --panel-border: rgba(0, 255, 214, 0.5);
+  --accent: #00ffd0;
+  --accent-strong: #ff4dd8;
+  --text-primary: #f5fffb;
+  --text-secondary: rgba(229, 255, 248, 0.72);
+  --warning: #ffc857;
+  --danger: #ff6b6b;
+  --positive: #70ffb0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Press Start 2P', 'Share Tech Mono', 'Courier New', monospace;
+  color: var(--text-primary);
+  background: radial-gradient(circle at top, rgba(10, 20, 60, 0.65) 0%, transparent 45%),
+    linear-gradient(180deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
+  position: relative;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(0, 255, 209, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 255, 209, 0.1) 1px, transparent 1px);
+  background-size: 80px 80px;
+  opacity: 0.25;
+  mix-blend-mode: screen;
+  z-index: 0;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    rgba(0, 0, 0, 0.08) 0%,
+    rgba(0, 0, 0, 0.22) 50%,
+    rgba(0, 0, 0, 0.08) 100%
+  );
+  background-size: 100% 4px;
+  opacity: 0.45;
+  mix-blend-mode: overlay;
+  z-index: 1;
+}
+
+.crt-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.08) 0%, transparent 60%);
+  mix-blend-mode: soft-light;
+  opacity: 0.65;
+  z-index: 2;
+}
+
+.header {
+  position: relative;
+  z-index: 5;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.title {
+  font-size: clamp(2.4rem, 3vw + 1rem, 3.8rem);
+  color: var(--accent);
+  text-shadow: 0 0 10px rgba(0, 255, 208, 0.9), 0 0 25px rgba(255, 77, 216, 0.8);
+  animation: pulse 4s ease-in-out infinite;
+}
+
+.subtitle {
+  font-size: clamp(1rem, 1.5vw + 0.2rem, 1.4rem);
+  color: var(--text-secondary);
+  margin-top: 0.4rem;
+}
+
+.timeline {
+  margin-top: 0.8rem;
+  font-size: 0.8rem;
+  color: rgba(250, 255, 252, 0.75);
+  letter-spacing: 0.22rem;
+}
+
+.dashboard {
+  position: relative;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.4rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  padding: 1.25rem;
+  border-radius: 1.1rem;
+  box-shadow: 0 0 22px rgba(0, 255, 214, 0.18), inset 0 0 25px rgba(0, 10, 26, 0.9);
+  position: relative;
+  overflow: hidden;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 77, 216, 0.25);
+  opacity: 0.75;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.panel h2 {
+  margin: 0 0 1.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.28rem;
+  color: var(--accent);
+  text-shadow: 0 0 12px rgba(0, 255, 214, 0.6);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  background: rgba(10, 15, 40, 0.6);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(0, 255, 214, 0.18);
+  position: relative;
+  min-height: 88px;
+}
+
+.metric::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 77, 216, 0.15);
+  pointer-events: none;
+}
+
+.metric .label {
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.15rem;
+}
+
+.metric .value {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  text-shadow: 0 0 6px rgba(0, 255, 214, 0.55);
+}
+
+.product-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9rem;
+  font-size: 0.7rem;
+}
+
+.product-card {
+  padding: 0.9rem;
+  border-radius: 0.8rem;
+  background: rgba(5, 10, 30, 0.75);
+  border: 1px solid rgba(0, 255, 214, 0.2);
+  box-shadow: inset 0 0 12px rgba(0, 255, 214, 0.12);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.product-card .name {
+  color: var(--accent);
+}
+
+.product-card .market {
+  color: var(--text-secondary);
+}
+
+.product-card .stat {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.product-list.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 96px;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+}
+
+.markets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.market-card {
+  padding: 1rem;
+  border-radius: 0.9rem;
+  background: rgba(7, 12, 35, 0.75);
+  border: 1px solid rgba(0, 255, 214, 0.18);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.market-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.18rem;
+  color: var(--accent);
+}
+
+.market-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+}
+
+.share-bar {
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(0, 255, 214, 0.18);
+  display: flex;
+}
+
+.share-bar .player {
+  background: linear-gradient(90deg, var(--accent), rgba(0, 255, 208, 0.4));
+}
+
+.share-bar .ai {
+  background: linear-gradient(90deg, rgba(255, 77, 216, 0.85), rgba(255, 77, 216, 0.4));
+}
+
+.trend {
+  font-size: 0.6rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.12rem;
+}
+
+.actions-panel .action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.actions-panel button {
+  flex: 1 1 220px;
+  padding: 0.85rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(0, 255, 214, 0.35);
+  background: linear-gradient(135deg, rgba(0, 60, 70, 0.9), rgba(0, 255, 214, 0.2));
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.7rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 0 12px rgba(0, 255, 214, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.actions-panel button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 20px rgba(0, 255, 214, 0.3);
+  background: linear-gradient(135deg, rgba(0, 80, 90, 0.95), rgba(0, 255, 214, 0.4));
+}
+
+.actions-panel button:active {
+  transform: translateY(1px);
+}
+
+.actions-panel .advance {
+  border-color: rgba(255, 77, 216, 0.6);
+  background: linear-gradient(135deg, rgba(60, 0, 55, 0.9), rgba(255, 77, 216, 0.25));
+}
+
+.action-description {
+  margin-top: 1rem;
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  min-height: 3.5rem;
+}
+
+.log {
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.75rem;
+  padding-right: 0.4rem;
+}
+
+.log-entry {
+  font-size: 0.65rem;
+  line-height: 1.6;
+  padding: 0.7rem 0.8rem;
+  background: rgba(5, 10, 28, 0.7);
+  border-left: 3px solid var(--accent);
+  border-radius: 0.6rem;
+  box-shadow: inset 0 0 12px rgba(0, 255, 214, 0.1);
+}
+
+.log-entry.positive {
+  border-color: var(--positive);
+  color: var(--positive);
+}
+
+.log-entry.warning {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.log-entry.negative {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.log-entry.system {
+  border-color: rgba(0, 255, 214, 0.6);
+}
+
+.ai-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9rem;
+  font-size: 0.65rem;
+}
+
+.ai-card {
+  padding: 0.9rem;
+  border-radius: 0.8rem;
+  background: rgba(6, 10, 32, 0.8);
+  border: 1px solid rgba(255, 77, 216, 0.3);
+  box-shadow: inset 0 0 15px rgba(255, 77, 216, 0.25);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.ai-card .name {
+  font-size: 0.7rem;
+  color: var(--accent-strong);
+  letter-spacing: 0.18rem;
+}
+
+.ai-card .stat {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.chart-panel {
+  grid-column: 1 / -1;
+}
+
+#valuation-chart {
+  width: 100%;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(0, 255, 214, 0.25);
+  background: rgba(4, 8, 24, 0.75);
+  box-shadow: inset 0 0 20px rgba(0, 255, 214, 0.12);
+}
+
+.footer {
+  text-align: center;
+  font-size: 0.6rem;
+  color: rgba(240, 255, 250, 0.5);
+  letter-spacing: 0.18rem;
+  z-index: 5;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
+  z-index: 50;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: rgba(10, 18, 40, 0.95);
+  border-radius: 1rem;
+  border: 1px solid rgba(0, 255, 214, 0.6);
+  padding: 1.4rem;
+  width: min(420px, 92vw);
+  box-shadow: 0 0 25px rgba(0, 255, 214, 0.3);
+}
+
+.modal-content h3 {
+  margin-top: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.22rem;
+  color: var(--accent);
+}
+
+.modal-actions {
+  margin-top: 1.1rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.modal-actions button {
+  flex: 0 0 auto;
+  padding: 0.65rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(0, 255, 214, 0.35);
+  background: rgba(0, 40, 50, 0.75);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.65rem;
+  letter-spacing: 0.16rem;
+  cursor: pointer;
+}
+
+.modal-actions button.cancel {
+  border-color: rgba(255, 77, 216, 0.35);
+  background: rgba(70, 0, 70, 0.65);
+}
+
+.modal-actions button.confirm {
+  border-color: rgba(0, 255, 214, 0.6);
+  background: rgba(0, 255, 214, 0.2);
+}
+
+.modal-actions button:hover {
+  box-shadow: 0 0 12px rgba(0, 255, 214, 0.3);
+}
+
+select,
+input[type='number'] {
+  width: 100%;
+  padding: 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(0, 255, 214, 0.25);
+  background: rgba(10, 20, 45, 0.8);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.7rem;
+  letter-spacing: 0.1rem;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    text-shadow: 0 0 10px rgba(0, 255, 208, 0.8), 0 0 32px rgba(255, 77, 216, 0.65);
+  }
+  50% {
+    text-shadow: 0 0 20px rgba(0, 255, 214, 0.9), 0 0 40px rgba(255, 77, 216, 0.85);
+  }
+}
+
+@media (max-width: 960px) {
+  body {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .actions-panel button {
+    flex: 1 1 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .title {
+    letter-spacing: 0.2rem;
+  }
+
+  .panel h2 {
+    letter-spacing: 0.18rem;
+  }
+}
+
+.is-hidden {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- add a `web/` experience with retro styled HTML, CSS and JavaScript gameplay for running Technopoly directly in the browser
- implement turn-based simulation logic, AI rival behaviour, event deck, and valuation chart updates in the new web client
- document how to launch the retro web edition in the repository README

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9891f93b88322b9d080c32e8b49e4